### PR TITLE
feature/browzine-summon-adapter-rework-BZ-4161

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ browzine.script.src = "https://s3.amazonaws.com/browzine-adapters/summon/browzin
 document.head.appendChild(browzine.script);
 ```
 
-Summon 2.0 External Script
+Summon Custom Scripts are added in the Summon 2.0 External Script portion of the Summon Editor Settings:
+![Summon 2.0 Editor Link](https://i.imgur.com/HJFpDGm.png "Summon 2.0 Editor Link")
+
+As a Custom Script Url:
 ![Summon 2.0 External Script](https://i.imgur.com/piLMSic.png "Summon 2.0 External Script")
 
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # Library Developers
 
 ## Overview
-Use `browzine-summon-adapter` to enhance Summon search results with BrowZine data; Adds links to Journal and Article content in BrowZine; Uses BrowZine Journal covers.
+Use `browzine-summon-adapter` to enhance Summon search results with BrowZine data; Adds links to Journal and Article content in BrowZine; Uses BrowZine Journal covers. The BrowZine Summon adapter supports IE11+ and evergreen browsers (Chrome, Firefox, Safari, Microsoft Edge).
+
 
 ![Article in Context links in Summon results](https://i.imgur.com/B34LEec.png "Article in Context links in Summon results")
 
 ## How to request your library API endpoint
 Visit Third Iron support to request your library API endpoint - http://support.thirdiron.com/
 
-You will receive your `api` endpoint and your `apiKey`, update the Summon script with these values.
+You will receive your `api` endpoint and your `apiKey`, update the following code snippet with these values and add to your Summon Custom Script:
 
-## What source code to use?
-Use `/src/browzine-summon-adapter.js`, we support IE10+ and evergreen browsers (Chrome, Firefox, Safari, Microsoft Edge).
+```
+var browzine = {
+  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
+  apiKey: "ENTER API KEY"
+};
+
+browzine.script = document.createElement("script");
+browzine.script.src = "https://s3.amazonaws.com/browzine-adapters/summon/browzine-summon-adapter.js";
+document.head.appendChild(browzine.script);
+```
+
+Summon 2.0 External Script
+![Summon 2.0 External Script](https://i.imgur.com/piLMSic.png "Summon 2.0 External Script")
 
 
 # Contributors

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will receive your `api` endpoint and your `apiKey`, update the following cod
 ```
 var browzine = {
   api: "https://api.thirdiron.com/public/v1/libraries/XXX",
-  apiKey: "ENTER API KEY"
+  apiKey: "ENTER API KEY",
 };
 
 browzine.script = document.createElement("script");
@@ -28,6 +28,22 @@ Summon Custom Scripts are added in the Summon 2.0 External Script portion of the
 As a Custom Script Url:
 ![Summon 2.0 External Script](https://i.imgur.com/piLMSic.png "Summon 2.0 External Script")
 
+## Customize The BrowZine Enhancement
+
+Customize the naming conventions for each type of search result - Journal/Article - by changing the wording in the quotes below:
+
+E.g. You can customize "View the Journal" and "View Complete Issue" or "Browse Now". These customizations are optional and the defaults are shown below.
+
+```
+var browzine = {
+  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
+  apiKey: "ENTER API KEY",
+  journalWording: "View the Journal",
+  articleWording: "View Complete Issue",
+  journalBrowZineWebLinkText: "Browse Now",
+  articleBrowZineWebLinkText: "Browse Now",
+};
+```
 
 # Contributors
 
@@ -53,7 +69,7 @@ Contributors should:
 - Make the needed changes in `/src/browzine-summon-adapter.js`.
 - Add a test for the change in `/tests/browzine-summon-adapter.js`.
 
-### Deploying (Internal Use Only)
+### Deploying
 
 CircleCI executes deployments to S3 using the deploy-staging and deploy-production npm commands. Neither feature branches nor hotfix branches are deployed to S3.
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,9 +29,9 @@ module.exports = function(config) {
     },
 
     // test results reporter to use
-    // possible values: 'dots', 'progress'
+    // possible values: 'dots', 'progress', 'mocha'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['mocha'],
+    reporters: ['progress'],
 
     // web server port
     port: 9876,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['mocha'],
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "angular-route": "1.6.4",
     "deploy-web-to-s3": "^1.2.1",
     "http-server": "^0.10.0",
+    "jasmine-core": "2.8.0",
     "jquery": "^2.1.3",
     "karma": "1.7.1",
-    "jasmine-core": "2.8.0",
     "karma-jasmine": "1.1.0",
+    "karma-mocha-reporter": "^2.2.4",
     "karma-phantomjs-launcher": "1.0.4",
     "ngrok": "^2.2.21",
     "recursive-replace": "^1.0.1"

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -149,14 +149,7 @@ browzine.search = (function() {
   };
 
   function getScope(documentSummary) {
-    var token = Object.getOwnPropertyNames(documentSummary).filter(function(property) {
-      property = property.replace(/[^a-z]/gi, "");
-      return property.indexOf("jQuery") === 0;
-    });
-
-    var scope = documentSummary[token].$scope;
-
-    return scope;
+    return angular.element(documentSummary).scope();
   };
 
   function resultsWithBrowZine(documentSummary) {

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -1,9 +1,8 @@
-var browzine = {
-  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
-  apiKey: "ENTER API KEY"
-};
-
 $(function() {
+  if(typeof browzine === "undefined" || browzine === null) {
+    return;
+  }
+
   var api = browzine.api;
   var apiKey = browzine.apiKey;
   var bookIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png";

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -194,7 +194,7 @@ browzine.search = (function() {
 }());
 
 $(function() {
-  if(typeof browzine === "undefined" || browzine === null) {
+  if(!browzine) {
     return;
   }
 

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -9,7 +9,8 @@ $(function() {
 
   function isArticle(data) {
     if(typeof data.document !== "undefined" && data.document !== null) {
-      return data.document.content_type.trim() === "Journal Article";
+      var contentType = data.document.content_type.trim();
+      return contentType === "Journal Article";
     } else {
       return data.type === "articles";
     }
@@ -17,7 +18,8 @@ $(function() {
 
   function isJournal(data) {
     if(typeof data.document !== "undefined" && data.document !== null) {
-      return data.document.content_type.trim() === "Journal";
+      var contentType = data.document.content_type.trim();
+      return contentType === "Journal" || contentType === "eJournal";
     } else {
       return data.type === "journals";
     }
@@ -30,10 +32,8 @@ $(function() {
       issn = scope.document.issns[0].trim().replace('-', '');
     }
 
-    if(issn === "") {
-      if(typeof scope.document.eissns !== "undefined" && scope.document.eissns !== null) {
-        issn = scope.document.eissns[0].trim().replace('-', '');
-      }
+    if(typeof scope.document.eissns !== "undefined" && scope.document.eissns !== null && issn === "") {
+      issn = scope.document.eissns[0].trim().replace('-', '');
     }
 
     return encodeURIComponent(issn);

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -135,7 +135,9 @@ $(function() {
     return template;
   };
 
-  function documentSummary(scope, element) {
+  function searchResultsWithBrowZine(documentSummary) {
+    var scope = angular.element(documentSummary).scope();
+
     if(!shouldEnhance(scope)) {
       return;
     }
@@ -149,18 +151,13 @@ $(function() {
 
       if(browzineWebLink) {
         var template = buildTemplate(data, browzineWebLink, bookIcon);
-        $(element).find(".docFooter .row:eq(0)").append(template);
+        $(documentSummary).find(".docFooter .row:eq(0)").append(template);
       }
 
       if(coverImageUrl) {
-        $(element).find(".coverImage img").attr("src", coverImageUrl);
+        $(documentSummary).find(".coverImage img").attr("src", coverImageUrl);
       }
     });
-  };
-
-  function browzineEnhance(element) {
-    var scope = angular.element(element).scope();
-    documentSummary(scope, element);
   };
 
   var results = document.querySelector("#results");
@@ -175,14 +172,14 @@ $(function() {
   var documentSummaries = results.querySelectorAll(".documentSummary");
 
   Array.prototype.forEach.call(documentSummaries, function(documentSummary) {
-    browzineEnhance(documentSummary);
+    searchResultsWithBrowZine(documentSummary);
   });
 
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
       if(mutation.attributeName === "document-summary") {
         var documentSummary = mutation.target;
-        browzineEnhance(documentSummary);
+        searchResultsWithBrowZine(documentSummary);
       }
     });
   });

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -135,7 +135,6 @@ browzine.search = (function() {
       browzineWebLinkText = browzine.articleBrowZineWebLinkText || "Browse Now";
     }
 
-    // You can change the underlined "Browse Now" link name on line 122 below.
     var template = "<div class='browzine'>" +
                      "{{wording}}: <a class='browzine-web-link' href='{{browzineWebLink}}' target='_blank' style='text-decoration: underline; color: #333;'>{{browzineWebLinkText}}</a> " +
                      "<img class='browzine-book-icon' src='{{bookIcon}}'/>" +
@@ -149,8 +148,19 @@ browzine.search = (function() {
     return template;
   };
 
+  function getScope(documentSummary) {
+    var token = Object.getOwnPropertyNames(documentSummary).filter(function(property) {
+      property = property.replace(/[^a-z]/gi, "");
+      return property.indexOf("jQuery") === 0;
+    });
+
+    var scope = documentSummary[token].$scope;
+
+    return scope;
+  };
+
   function resultsWithBrowZine(documentSummary) {
-    var scope = angular.element(documentSummary).scope();
+    var scope = getScope(documentSummary);
 
     if(!shouldEnhance(scope)) {
       return;
@@ -176,6 +186,7 @@ browzine.search = (function() {
 
   return {
     resultsWithBrowZine: resultsWithBrowZine,
+    getScope: getScope,
     shouldEnhance: shouldEnhance,
     getEndpoint: getEndpoint,
     getData: getData,

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -39,12 +39,14 @@ browzine.search = (function() {
   function getIssn(scope) {
     var issn = "";
 
-    if(scope.document.issns) {
-      issn = scope.document.issns[0].trim().replace('-', '');
-    }
+    if(scope.document) {
+      if(scope.document.issns) {
+        issn = scope.document.issns[0].trim().replace('-', '');
+      }
 
-    if(scope.document.eissns && issn === "") {
-      issn = scope.document.eissns[0].trim().replace('-', '');
+      if(scope.document.eissns && issn === "") {
+        issn = scope.document.eissns[0].trim().replace('-', '');
+      }
     }
 
     return encodeURIComponent(issn);
@@ -53,8 +55,10 @@ browzine.search = (function() {
   function getDoi(scope) {
     var doi = "";
 
-    if(scope.document.dois) {
-      doi = scope.document.dois[0].trim();
+    if(scope.document) {
+      if(scope.document.dois) {
+        doi = scope.document.dois[0].trim();
+      }
     }
 
     return encodeURIComponent(doi);

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -5,14 +5,14 @@ browzine.search = (function() {
   function isArticle(data) {
     var result = false;
 
-    if(typeof data.document !== "undefined" && data.document !== null) {
-      if(typeof data.document.content_type !== "undefined" && data.document.content_type !== null) {
+    if(data.document) {
+      if(data.document.content_type) {
         var contentType = data.document.content_type.trim();
         result = (contentType === "Journal Article");
       }
     }
 
-    if(typeof data.type !== "undefined" && data.type !== null) {
+    if(data.type) {
       result = (data.type === "articles");
     }
 
@@ -22,14 +22,14 @@ browzine.search = (function() {
   function isJournal(data) {
     var result = false;
 
-    if(typeof data.document !== "undefined" && data.document !== null) {
-      if(typeof data.document.content_type !== "undefined" && data.document.content_type !== null) {
+    if(data.document) {
+      if(data.document.content_type) {
         var contentType = data.document.content_type.trim();
         result = (contentType === "Journal" || contentType === "eJournal");
       }
     }
 
-    if(typeof data.type !== "undefined" && data.type !== null) {
+    if(data.type) {
       result = (data.type === "journals");
     }
 
@@ -39,11 +39,11 @@ browzine.search = (function() {
   function getIssn(scope) {
     var issn = "";
 
-    if(typeof scope.document.issns !== "undefined" && scope.document.issns !== null) {
+    if(scope.document.issns) {
       issn = scope.document.issns[0].trim().replace('-', '');
     }
 
-    if(typeof scope.document.eissns !== "undefined" && scope.document.eissns !== null && issn === "") {
+    if(scope.document.eissns && issn === "") {
       issn = scope.document.eissns[0].trim().replace('-', '');
     }
 
@@ -53,7 +53,7 @@ browzine.search = (function() {
   function getDoi(scope) {
     var doi = "";
 
-    if(typeof scope.document.dois !== "undefined" && scope.document.dois !== null) {
+    if(scope.document.dois) {
       doi = scope.document.dois[0].trim();
     }
 
@@ -91,7 +91,7 @@ browzine.search = (function() {
   function getBrowZineWebLink(data) {
     var browzineWebLink = null;
 
-    if(typeof data.browzineWebLink !== "undefined" && data.browzineWebLink !== null) {
+    if(data.browzineWebLink) {
       browzineWebLink = data.browzineWebLink;
     }
 
@@ -102,16 +102,16 @@ browzine.search = (function() {
     var coverImageUrl = null;
 
     if(isJournal(data)) {
-      if(typeof data.coverImageUrl !== "undefined" && data.coverImageUrl !== null) {
+      if(data.coverImageUrl) {
         coverImageUrl = data.coverImageUrl;
       }
     }
 
     if(isArticle(data)) {
-      if(typeof response.included !== "undefined" && response.included !== null) {
+      if(response.included) {
         var journal = getIncludedJournal(response);
 
-        if(typeof journal.coverImageUrl !== "undefined" && journal.coverImageUrl !== null) {
+        if(journal.coverImageUrl) {
           coverImageUrl = journal.coverImageUrl;
         }
       }

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -154,7 +154,7 @@ $(function() {
     });
   };
 
-  function browZineEnhance(element) {
+  function browzineEnhance(element) {
     var secret = Object.getOwnPropertyNames(element).filter(function(property) {
       property = property.replace(/[^a-z]/gi, "");
       return property.indexOf("jQuery") === 0;
@@ -177,14 +177,14 @@ $(function() {
   var documentSummaries = results.querySelectorAll(".documentSummary");
 
   Array.prototype.forEach.call(documentSummaries, function(documentSummary) {
-    browZineEnhance(documentSummary);
+    browzineEnhance(documentSummary);
   });
 
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
       if(mutation.attributeName === "document-summary") {
         var documentSummary = mutation.target;
-        browZineEnhance(documentSummary);
+        browzineEnhance(documentSummary);
       }
     });
   });

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -1,3 +1,8 @@
+var browzine = {
+  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
+  apiKey: "ENTER API KEY"
+};
+
 $(function() {
   var api = browzine.api;
   var apiKey = browzine.apiKey;

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -140,14 +140,14 @@ browzine.search = (function() {
     }
 
     var template = "<div class='browzine'>" +
-                     "{{wording}}: <a class='browzine-web-link' href='{{browzineWebLink}}' target='_blank' style='text-decoration: underline; color: #333;'>{{browzineWebLinkText}}</a> " +
-                     "<img class='browzine-book-icon' src='{{bookIcon}}'/>" +
+                     "{wording}: <a class='browzine-web-link' href='{browzineWebLink}' target='_blank' style='text-decoration: underline; color: #333;'>{browzineWebLinkText}</a> " +
+                     "<img class='browzine-book-icon' src='{bookIcon}'/>" +
                    "</div>";
 
-    template = template.replace(/{{wording}}/g, wording);
-    template = template.replace(/{{browzineWebLink}}/g, browzineWebLink);
-    template = template.replace(/{{browzineWebLinkText}}/g, browzineWebLinkText);
-    template = template.replace(/{{bookIcon}}/g, bookIcon);
+    template = template.replace(/{wording}/g, wording);
+    template = template.replace(/{browzineWebLink}/g, browzineWebLink);
+    template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
+    template = template.replace(/{bookIcon}/g, bookIcon);
 
     return template;
   };

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -145,7 +145,7 @@ $(function() {
 
       if(browzineWebLink) {
         var template = buildTemplate(data, browzineWebLink, bookIcon);
-        $(element).find(".docFooter .row:first").append(template);
+        $(element).find(".docFooter .row:eq(0)").append(template);
       }
 
       if(coverImageUrl) {
@@ -155,13 +155,7 @@ $(function() {
   };
 
   function browzineEnhance(element) {
-    var secret = Object.getOwnPropertyNames(element).filter(function(property) {
-      property = property.replace(/[^a-z]/gi, "");
-      return property.indexOf("jQuery") === 0;
-    });
-
-    var scope = element[secret].$scope;
-
+    var scope = angular.element(element).scope();
     documentSummary(scope, element);
   };
 

--- a/src/browzine-summon-adapter.js
+++ b/src/browzine-summon-adapter.js
@@ -110,26 +110,28 @@ $(function() {
   };
 
   function buildTemplate(data, browzineWebLink, bookIcon) {
-    var assetClass = "";
+    var wording = "";
+    var browzineWebLinkText = "";
 
-    // Customize the naming conventions for each type of item - Journal/Article - by changing the wording in the quotes below:
-    // E.g. You can customize "View the Journal" and "View Complete Issue".
     if(isJournal(data)) {
-      assetClass = "View the Journal";
+      wording = browzine.journalWording || "View the Journal";
+      browzineWebLinkText = browzine.journalBrowZineWebLinkText || "Browse Now";
     }
 
     if(isArticle(data)) {
-      assetClass = "View Complete Issue";
+      wording = browzine.articleWording || "View Complete Issue";
+      browzineWebLinkText = browzine.articleBrowZineWebLinkText || "Browse Now";
     }
 
     // You can change the underlined "Browse Now" link name on line 122 below.
     var template = "<div class='browzine'>" +
-                     "{{assetClass}}: <a class='browzine-web-link' href='{{browzineWebLink}}' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> " +
+                     "{{wording}}: <a class='browzine-web-link' href='{{browzineWebLink}}' target='_blank' style='text-decoration: underline; color: #333;'>{{browzineWebLinkText}}</a> " +
                      "<img class='browzine-book-icon' src='{{bookIcon}}'/>" +
                    "</div>";
 
-    template = template.replace(/{{assetClass}}/g, assetClass);
+    template = template.replace(/{{wording}}/g, wording);
     template = template.replace(/{{browzineWebLink}}/g, browzineWebLink);
+    template = template.replace(/{{browzineWebLinkText}}/g, browzineWebLinkText);
     template = template.replace(/{{bookIcon}}/g, bookIcon);
 
     return template;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1,33 +1,27 @@
-//Note: We may not be able to use this test suite until Summon fixes
-//its LABjs use to bootstrap Angular once all scripts (3rd-party, custom) are loaded.
-//Even after getting the tests to run w/ MutationObserver, running into
-//async timing issue where the enahncement updates are nondeterministic.
 describe("BrowZine Summon Adapter", function() {
-  var compile, scope, documentSummaryElement, resultsElement, httpBackend;
+  var search = {}, documentSummary = {};
 
   $("body").append("<div id='results'></div>");
 
-  function getCompiledDocumentSummaryDirective() {
-    var compiledDirective = compile(angular.element("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>"))(scope);
-    scope.$digest();
-    return compiledDirective;
-  }
-
   describe("search results journal", function() {
     beforeEach(function() {
-      module('summonApp.directives');
+      search = browzine.search;
 
-      inject(function ($compile, $rootScope, $httpBackend) {
-        compile = $compile;
-        scope = $rootScope.$new();
-        httpBackend = $httpBackend;
+      documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-        scope.document = {
-          content_type: "Journal",
-          issns: ["0028-4793"]
-        };
+      $.extend(documentSummary, {
+        "jQuery321088802690231186742": {
+          "$scope": {
+            "document": {
+              content_type: "Journal",
+              issns: ["0028-4793"]
+            }
+          }
+        }
+      });
 
-        httpBackend.whenGET(/search\?issns=00284793/).respond({
+      $.getJSON = function(endpoint, callback) {
+        return callback({
           "data": [{
             "id": 10292,
             "type": "journals",
@@ -39,46 +33,50 @@ describe("BrowZine Summon Adapter", function() {
             "browzineWebLink": "https://browzine.com/libraries/XXX/journals/10292"
           }]
         });
-      });
+      };
 
-      documentSummaryElement = getCompiledDocumentSummaryDirective();
+      search.resultsWithBrowZine(documentSummary);
+    });
+
+    afterEach(function() {
+
     });
 
     it("should have an enhanced browse journal in browzine option", function() {
-      // httpBackend.flush();
-      //
-      // var template = documentSummaryElement.find(".browzine");
-      // expect(template).toBeDefined();
-      // expect(template.text().trim()).toEqual("View the Journal: Browse Now");
-      // expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
-      // expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      // expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      var template = documentSummary.find(".browzine");
+      expect(template).toBeDefined();
+      expect(template.text().trim()).toEqual("View the Journal: Browse Now");
+      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
+      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {
-      // httpBackend.flush();
-      //
-      // var coverImage = documentSummaryElement.find(".coverImage img");
-      // expect(coverImage).toBeDefined();
-      // expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      var coverImage = documentSummary.find(".coverImage img");
+      expect(coverImage).toBeDefined();
+      expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
   });
 
   describe("search results article", function() {
     beforeEach(function() {
-      module('summonApp.directives');
+      search = browzine.search;
 
-      inject(function ($compile, $rootScope, $httpBackend) {
-        compile = $compile;
-        scope = $rootScope.$new();
-        httpBackend = $httpBackend;
+      documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-        scope.document = {
-          content_type: "Journal Article",
-          dois: ["10.1136/bmj.h2575"]
-        };
+      $.extend(documentSummary, {
+        "jQuery321088802690231186742": {
+          "$scope": {
+            "document": {
+              content_type: "Journal Article",
+              dois: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      });
 
-        httpBackend.whenGET(/articles\/doi\/10.1136%2Fbmj.h2575/).respond({
+      $.getJSON = function(endpoint, callback) {
+        return callback({
           "data": {
             "id": 55134408,
             "type": "articles",
@@ -102,46 +100,50 @@ describe("BrowZine Summon Adapter", function() {
             "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
           }]
         });
-      });
+      };
 
-      documentSummaryElement = getCompiledDocumentSummaryDirective();
+      search.resultsWithBrowZine(documentSummary);
+    });
+
+    afterEach(function() {
+
     });
 
     it("should have an enhanced browse article in browzine option", function() {
-      // httpBackend.flush();
-      //
-      // var template = documentSummaryElement.find(".browzine");
-      // expect(template).toBeDefined();
-      // expect(template.text().trim()).toEqual("View Complete Issue: Browse Now");
-      // expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-      // expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      // expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      var template = documentSummary.find(".browzine");
+      expect(template).toBeDefined();
+      expect(template.text().trim()).toEqual("View Complete Issue: Browse Now");
+      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {
-      // httpBackend.flush();
-      //
-      // var coverImage = documentSummaryElement.find(".coverImage img");
-      // expect(coverImage).toBeDefined();
-      // expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+      var coverImage = documentSummary.find(".coverImage img");
+      expect(coverImage).toBeDefined();
+      expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
     });
   });
 
   describe("search results article with no browzineWebLink", function() {
     beforeEach(function() {
-      module('summonApp.directives');
+      search = browzine.search;
 
-      inject(function ($compile, $rootScope, $httpBackend) {
-        compile = $compile;
-        scope = $rootScope.$new();
-        httpBackend = $httpBackend;
+      documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-        scope.document = {
-          content_type: "Journal Article",
-          dois: ["10.1136/bmj.h2575"]
-        };
+      $.extend(documentSummary, {
+        "jQuery321088802690231186742": {
+          "$scope": {
+            "document": {
+              content_type: "Journal Article",
+              dois: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      });
 
-        httpBackend.whenGET(/articles\/doi\/10.1136%2Fbmj.h2575/).respond({
+      $.getJSON = function(endpoint, callback) {
+        return callback({
           "data": {
             "id": 55134408,
             "type": "articles",
@@ -164,16 +166,18 @@ describe("BrowZine Summon Adapter", function() {
             "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
           }]
         });
-      });
+      };
 
-      documentSummaryElement = getCompiledDocumentSummaryDirective();
+      search.resultsWithBrowZine(documentSummary);
+    });
+
+    afterEach(function() {
+
     });
 
     it("should not have an enhanced browse article in browzine option", function() {
-      // httpBackend.flush();
-      //
-      // var template = documentSummaryElement.find(".browzine");
-      // expect(template.text().trim()).toEqual("");
+      var template = documentSummary.find(".browzine");
+      expect(template.text().trim()).toEqual("");
     });
   });
 });

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1,5 +1,11 @@
+//Note: We may not be able to use this test suite until Summon fixes
+//its LABjs use to bootstrap Angular once all scripts (3rd-party, custom) are loaded.
+//Even after getting the tests to run w/ MutationObserver, running into
+//async timing issue where the enahncement updates are nondeterministic.
 describe("BrowZine Summon Adapter", function() {
-  var compile, scope, documentSummaryElement, httpBackend;
+  var compile, scope, documentSummaryElement, resultsElement, httpBackend;
+
+  $("body").append("<div id='results'></div>");
 
   function getCompiledDocumentSummaryDirective() {
     var compiledDirective = compile(angular.element("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>"))(scope);
@@ -39,22 +45,22 @@ describe("BrowZine Summon Adapter", function() {
     });
 
     it("should have an enhanced browse journal in browzine option", function() {
-      httpBackend.flush();
-
-      var template = documentSummaryElement.find(".browzine");
-      expect(template).toBeDefined();
-      expect(template.text().trim()).toEqual("View the Journal: Browse Now");
-      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
-      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      // httpBackend.flush();
+      //
+      // var template = documentSummaryElement.find(".browzine");
+      // expect(template).toBeDefined();
+      // expect(template.text().trim()).toEqual("View the Journal: Browse Now");
+      // expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
+      // expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+      // expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {
-      httpBackend.flush();
-
-      var coverImage = documentSummaryElement.find(".coverImage img");
-      expect(coverImage).toBeDefined();
-      expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      // httpBackend.flush();
+      //
+      // var coverImage = documentSummaryElement.find(".coverImage img");
+      // expect(coverImage).toBeDefined();
+      // expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
   });
 
@@ -102,22 +108,22 @@ describe("BrowZine Summon Adapter", function() {
     });
 
     it("should have an enhanced browse article in browzine option", function() {
-      httpBackend.flush();
-
-      var template = documentSummaryElement.find(".browzine");
-      expect(template).toBeDefined();
-      expect(template.text().trim()).toEqual("View Complete Issue: Browse Now");
-      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      // httpBackend.flush();
+      //
+      // var template = documentSummaryElement.find(".browzine");
+      // expect(template).toBeDefined();
+      // expect(template.text().trim()).toEqual("View Complete Issue: Browse Now");
+      // expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+      // expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+      // expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {
-      httpBackend.flush();
-
-      var coverImage = documentSummaryElement.find(".coverImage img");
-      expect(coverImage).toBeDefined();
-      expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+      // httpBackend.flush();
+      //
+      // var coverImage = documentSummaryElement.find(".coverImage img");
+      // expect(coverImage).toBeDefined();
+      // expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
     });
   });
 
@@ -164,10 +170,10 @@ describe("BrowZine Summon Adapter", function() {
     });
 
     it("should not have an enhanced browse article in browzine option", function() {
-      httpBackend.flush();
-
-      var template = documentSummaryElement.find(".browzine");
-      expect(template.text().trim()).toEqual("");
+      // httpBackend.flush();
+      //
+      // var template = documentSummaryElement.find(".browzine");
+      // expect(template.text().trim()).toEqual("");
     });
   });
 });

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1,9 +1,9 @@
-describe("BrowZine Summon Adapter", function() {
+describe("BrowZine Summon Adapter >", function() {
   var search = {}, documentSummary = {};
 
   $("body").append("<div id='results'></div>");
 
-  describe("search results journal", function() {
+  describe("search results journal >", function() {
     beforeEach(function() {
       search = browzine.search;
 
@@ -60,7 +60,7 @@ describe("BrowZine Summon Adapter", function() {
     });
   });
 
-  describe("search results article", function() {
+  describe("search results article >", function() {
     beforeEach(function() {
       search = browzine.search;
 
@@ -129,7 +129,7 @@ describe("BrowZine Summon Adapter", function() {
     });
   });
 
-  describe("search results article with no browzineWebLink", function() {
+  describe("search results article with no browzineWebLink >", function() {
     beforeEach(function() {
       search = browzine.search;
 

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -21,6 +21,8 @@ describe("BrowZine Summon Adapter", function() {
       });
 
       $.getJSON = function(endpoint, callback) {
+        expect(endpoint).toMatch(/search\?issns=00284793/);
+
         return callback({
           "data": [{
             "id": 10292,
@@ -76,6 +78,8 @@ describe("BrowZine Summon Adapter", function() {
       });
 
       $.getJSON = function(endpoint, callback) {
+        expect(endpoint).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+
         return callback({
           "data": {
             "id": 55134408,
@@ -136,13 +140,15 @@ describe("BrowZine Summon Adapter", function() {
 
         $scope.document = {
           content_type: "Journal Article",
-          dois: ["10.1136/bmj.h2575"]
+          dois: ["02.2016/bmj.h0830"]
         };
 
         documentSummary = $compile(documentSummary)($scope);
       });
 
       $.getJSON = function(endpoint, callback) {
+        expect(endpoint).toMatch(/articles\/doi\/02.2016%2Fbmj.h0830/);
+
         return callback({
           "data": {
             "id": 55134408,

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -9,15 +9,15 @@ describe("BrowZine Summon Adapter", function() {
 
       documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-      $.extend(documentSummary, {
-        "jQuery321088802690231186742": {
-          "$scope": {
-            "document": {
-              content_type: "Journal",
-              issns: ["0028-4793"]
-            }
-          }
-        }
+      inject(function ($compile, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $scope.document = {
+          content_type: "Journal",
+          issns: ["0028-4793"]
+        };
+
+        documentSummary = $compile(documentSummary)($scope);
       });
 
       $.getJSON = function(endpoint, callback) {
@@ -64,15 +64,15 @@ describe("BrowZine Summon Adapter", function() {
 
       documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-      $.extend(documentSummary, {
-        "jQuery321088802690231186742": {
-          "$scope": {
-            "document": {
-              content_type: "Journal Article",
-              dois: ["10.1136/bmj.h2575"]
-            }
-          }
-        }
+      inject(function ($compile, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $scope.document = {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        };
+
+        documentSummary = $compile(documentSummary)($scope);
       });
 
       $.getJSON = function(endpoint, callback) {
@@ -131,15 +131,15 @@ describe("BrowZine Summon Adapter", function() {
 
       documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-      $.extend(documentSummary, {
-        "jQuery321088802690231186742": {
-          "$scope": {
-            "document": {
-              content_type: "Journal Article",
-              dois: ["10.1136/bmj.h2575"]
-            }
-          }
-        }
+      inject(function ($compile, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $scope.document = {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        };
+
+        documentSummary = $compile(documentSummary)($scope);
       });
 
       $.getJSON = function(endpoint, callback) {

--- a/tests/credentials.js
+++ b/tests/credentials.js
@@ -1,0 +1,4 @@
+var browzine = {
+  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
+  apiKey: "ENTER API KEY",
+};

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -257,15 +257,15 @@ describe("Search Model", function() {
   it("should retrieve the scope from a search result", function() {
     var documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-    $.extend(documentSummary, {
-      "jQuery321088802690231186742": {
-        "$scope": {
-          "document": {
-            content_type: "Journal",
-            issns: ["0028-4793"]
-          }
-        }
-      }
+    inject(function ($compile, $rootScope) {
+      $scope = $rootScope.$new();
+
+      $scope.document = {
+        content_type: "Journal",
+        issns: ["0028-4793"]
+      };
+
+      documentSummary = $compile(documentSummary)($scope);
     });
 
     var scope = search.getScope(documentSummary);

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -235,4 +235,22 @@ describe("Search Model", function() {
     expect(template).toContain("text-decoration: underline;");
     expect(template).toContain("color: #333;");
   });
+
+  it("should build an enhancement template for article search results", function() {
+    var data = search.getData(articleResponse);
+    var browzineWebLink = search.getBrowZineWebLink(data);
+    var template = search.buildTemplate(data, browzineWebLink);
+
+    expect(data).toBeDefined();
+    expect(browzineWebLink).toBeDefined();
+    expect(template).toBeDefined();
+
+    expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
+    expect(template).toContain("View Complete Issue");
+    expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+    expect(template).toContain("Browse Now");
+    expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+    expect(template).toContain("text-decoration: underline;");
+    expect(template).toContain("color: #333;");
+  });
 });

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -1,0 +1,238 @@
+describe("Search Model", function() {
+  var search = {}, journalResponse = {}, articleResponse = {};
+
+  beforeEach(function() {
+    search = browzine.search;
+
+    journalResponse = {
+      "data": [{
+        "id": 10292,
+        "type": "journals",
+        "title": "New England Journal of Medicine (NEJM)",
+        "issn": "00284793",
+        "sjrValue": 14.619,
+        "coverImageUrl": "https://assets.thirdiron.com/images/covers/0028-4793.png",
+        "browzineEnabled": true,
+        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/10292"
+      }]
+    };
+
+    articleResponse = {
+      "data": {
+        "id": 55134408,
+        "type": "articles",
+        "title": "New England Journal of Medicine reconsiders relationship with industry",
+        "date": "2015-05-12",
+        "authors": "McCarthy, M.",
+        "inPress": false,
+        "availableThroughBrowzine": true,
+        "startPage": "h2575",
+        "endPage": "h2575",
+        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575"
+      },
+      "included": [{
+        "id": 18126,
+        "type": "journals",
+        "title": "theBMJ",
+        "issn": "09598138",
+        "sjrValue": 2.567,
+        "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+        "browzineEnabled": true,
+        "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+      }]
+    };
+  });
+
+  afterEach(function() {
+
+  });
+
+  it("search model should exist", function() {
+    expect(search).toBeDefined();
+  });
+
+  it("should detect whether a journal search result can be enhanced", function() {
+    var scope = {
+      document: {
+        content_type: "Journal",
+        issns: ["0028-4793"]
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(true);
+  });
+
+  it("should detect whether a eJournal search result can be enhanced", function() {
+    var scope = {
+      document: {
+        content_type: "eJournal",
+        issns: ["0028-479X"]
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(true);
+  });
+
+  it("should detect whether an article search result can be enhanced", function() {
+    var scope = {
+      document: {
+        content_type: "Journal Article",
+        dois: ["10.1136/bmj.h2575"]
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(true);
+  });
+
+  it("should not enhance a journal search result without an issn or eissn", function() {
+    var scope = {
+      document: {
+        content_type: "Journal"
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(false);
+  });
+
+  it("should not enhance an article search result without a doi", function() {
+    var scope = {
+      document: {
+        content_type: "Journal Article"
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(false);
+  });
+
+  it("should not enhance a journal search result without a content type", function() {
+    var scope = {
+      document: {
+        issns: ["0028-4793"]
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(false);
+  });
+
+  it("should not enhance an article search result without a content type", function() {
+    var scope = {
+      document: {
+        dois: ["10.1136/bmj.h2575"]
+      }
+    };
+
+    expect(search.shouldEnhance(scope)).toEqual(false);
+  });
+
+  it("should build a journal endpoint for a journal search result", function() {
+    var scope = {
+      document: {
+        content_type: "Journal",
+        issns: ["0028-4793"]
+      }
+    };
+
+    expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
+  });
+
+  it("should select the issn over the eissn when a journal search result includes both", function() {
+    var scope = {
+      document: {
+        content_type: "Journal",
+        issns: ["0028-4793"],
+        eissns: ["0082-3974"]
+      }
+    };
+
+    expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
+  });
+
+  it("should select the eissn when the journal search result has no issn", function() {
+    var scope = {
+      document: {
+        content_type: "Journal",
+        eissns: ["0082-3974"]
+      }
+    };
+
+    expect(search.getEndpoint(scope)).toContain("search?issns=00823974");
+  });
+
+  it("should build an article endpoint for an article search result", function() {
+    var scope = {
+      document: {
+        content_type: "Journal Article",
+        dois: ["10.1136/bmj.h2575"]
+      }
+    };
+
+    expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575");
+  });
+
+  it("should build an article endpoint for an article search result and include its journal", function() {
+    var scope = {
+      document: {
+        content_type: "Journal Article",
+        dois: ["10.1136/bmj.h2575"]
+      }
+    };
+
+    expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575?include=journal");
+  });
+
+  it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
+    var data = search.getData(journalResponse);
+    expect(data).toBeDefined();
+    expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
+  });
+
+  it("should include a browzineWebLink in the BrowZine API response for an article", function() {
+    var data = search.getData(articleResponse);
+    expect(data).toBeDefined();
+    expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+  });
+
+  it("should include a coverImageUrl in the BrowZine API response for a journal", function() {
+    var data = search.getData(journalResponse);
+    expect(data).toBeDefined();
+    expect(search.getCoverImageUrl(data, journalResponse)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+  });
+
+  it("should include a coverImageUrl in the BrowZine API response for an article", function() {
+    var data = search.getData(articleResponse);
+    expect(data).toBeDefined();
+    expect(search.getCoverImageUrl(data, articleResponse)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+  });
+
+  it("should not build a coverImageUrl when the BrowZine API response is missing the journal data type", function() {
+    var data = search.getData(journalResponse);
+    delete data.type;
+    expect(data).toBeDefined();
+    expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
+  });
+
+  it("should not build a coverImageUrl when the BrowZine API response is missing the article data type", function() {
+    var data = search.getData(articleResponse);
+    delete data.type;
+    expect(data).toBeDefined();
+    expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
+  });
+
+  it("should build an enhancement template for journal search results", function() {
+    var data = search.getData(journalResponse);
+    var browzineWebLink = search.getBrowZineWebLink(data);
+    var template = search.buildTemplate(data, browzineWebLink);
+
+    expect(data).toBeDefined();
+    expect(browzineWebLink).toBeDefined();
+    expect(template).toBeDefined();
+
+    expect(template).toEqual("<div class='browzine'>View the Journal: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
+    expect(template).toContain("View the Journal");
+    expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
+    expect(template).toContain("Browse Now");
+    expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+    expect(template).toContain("text-decoration: underline;");
+    expect(template).toContain("color: #333;");
+  });
+});

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -51,237 +51,249 @@ describe("Search Model", function() {
     expect(search).toBeDefined();
   });
 
-  it("should not enhance a search result without a document", function() {
-    var scope = {};
+  describe("search model getScope method", function() {
+    it("should retrieve the scope from a search result", function() {
+      var documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-    expect(search.shouldEnhance(scope)).toEqual(false);
+      inject(function ($compile, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $scope.document = {
+          content_type: "Journal",
+          issns: ["0028-4793"]
+        };
+
+        documentSummary = $compile(documentSummary)($scope);
+      });
+
+      var scope = search.getScope(documentSummary);
+
+      expect(scope).toBeDefined();
+      expect(scope.document).toBeDefined();
+      expect(scope.document.content_type).toBeDefined();
+      expect(scope.document.issns).toBeDefined();
+
+      expect(scope.document.content_type).toEqual("Journal");
+      expect(scope.document.issns).toEqual(["0028-4793"]);
+    });
   });
 
-  it("should enhance a journal search result with an issn", function() {
-    var scope = {
-      document: {
-        content_type: "Journal",
-        issns: ["0028-4793"]
-      }
-    };
+  describe("search model shouldEnhance method", function() {
+    it("should not enhance a search result without a document", function() {
+      var scope = {};
 
-    expect(search.shouldEnhance(scope)).toEqual(true);
-  });
-
-  it("should enhance an eJournal search result with an issn", function() {
-    var scope = {
-      document: {
-        content_type: "eJournal",
-        issns: ["0028-479X"]
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(true);
-  });
-
-  it("should enhance an article search result with a doi", function() {
-    var scope = {
-      document: {
-        content_type: "Journal Article",
-        dois: ["10.1136/bmj.h2575"]
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(true);
-  });
-
-  it("should not enhance a journal search result without an issn or eissn", function() {
-    var scope = {
-      document: {
-        content_type: "Journal"
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(false);
-  });
-
-  it("should not enhance an article search result without a doi", function() {
-    var scope = {
-      document: {
-        content_type: "Journal Article"
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(false);
-  });
-
-  it("should not enhance a journal search result without a content type", function() {
-    var scope = {
-      document: {
-        issns: ["0028-4793"]
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(false);
-  });
-
-  it("should not enhance an article search result without a content type", function() {
-    var scope = {
-      document: {
-        dois: ["10.1136/bmj.h2575"]
-      }
-    };
-
-    expect(search.shouldEnhance(scope)).toEqual(false);
-  });
-
-  it("should build a journal endpoint for a journal search result", function() {
-    var scope = {
-      document: {
-        content_type: "Journal",
-        issns: ["0028-4793"]
-      }
-    };
-
-    expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
-  });
-
-  it("should select the issn over the eissn when a journal search result includes both", function() {
-    var scope = {
-      document: {
-        content_type: "Journal",
-        issns: ["0028-4793"],
-        eissns: ["0082-3974"]
-      }
-    };
-
-    expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
-  });
-
-  it("should select the eissn when the journal search result has no issn", function() {
-    var scope = {
-      document: {
-        content_type: "Journal",
-        eissns: ["0082-3974"]
-      }
-    };
-
-    expect(search.getEndpoint(scope)).toContain("search?issns=00823974");
-  });
-
-  it("should build an article endpoint for an article search result", function() {
-    var scope = {
-      document: {
-        content_type: "Journal Article",
-        dois: ["10.1136/bmj.h2575"]
-      }
-    };
-
-    expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575");
-  });
-
-  it("should build an article endpoint for an article search result and include its journal", function() {
-    var scope = {
-      document: {
-        content_type: "Journal Article",
-        dois: ["10.1136/bmj.h2575"]
-      }
-    };
-
-    expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575?include=journal");
-  });
-
-  it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
-    var data = search.getData(journalResponse);
-    expect(data).toBeDefined();
-    expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
-  });
-
-  it("should include a browzineWebLink in the BrowZine API response for an article", function() {
-    var data = search.getData(articleResponse);
-    expect(data).toBeDefined();
-    expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-  });
-
-  it("should include a coverImageUrl in the BrowZine API response for a journal", function() {
-    var data = search.getData(journalResponse);
-    expect(data).toBeDefined();
-    expect(search.getCoverImageUrl(data, journalResponse)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
-  });
-
-  it("should include a coverImageUrl in the BrowZine API response for an article", function() {
-    var data = search.getData(articleResponse);
-    expect(data).toBeDefined();
-    expect(search.getCoverImageUrl(data, articleResponse)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
-  });
-
-  it("should not build a coverImageUrl when the BrowZine API response is missing the journal data type", function() {
-    var data = search.getData(journalResponse);
-    delete data.type;
-    expect(data).toBeDefined();
-    expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
-  });
-
-  it("should not build a coverImageUrl when the BrowZine API response is missing the article data type", function() {
-    var data = search.getData(articleResponse);
-    delete data.type;
-    expect(data).toBeDefined();
-    expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
-  });
-
-  it("should build an enhancement template for journal search results", function() {
-    var data = search.getData(journalResponse);
-    var browzineWebLink = search.getBrowZineWebLink(data);
-    var template = search.buildTemplate(data, browzineWebLink);
-
-    expect(data).toBeDefined();
-    expect(browzineWebLink).toBeDefined();
-    expect(template).toBeDefined();
-
-    expect(template).toEqual("<div class='browzine'>View the Journal: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
-    expect(template).toContain("View the Journal");
-    expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
-    expect(template).toContain("Browse Now");
-    expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
-    expect(template).toContain("text-decoration: underline;");
-    expect(template).toContain("color: #333;");
-  });
-
-  it("should build an enhancement template for article search results", function() {
-    var data = search.getData(articleResponse);
-    var browzineWebLink = search.getBrowZineWebLink(data);
-    var template = search.buildTemplate(data, browzineWebLink);
-
-    expect(data).toBeDefined();
-    expect(browzineWebLink).toBeDefined();
-    expect(template).toBeDefined();
-
-    expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
-    expect(template).toContain("View Complete Issue");
-    expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-    expect(template).toContain("Browse Now");
-    expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
-    expect(template).toContain("text-decoration: underline;");
-    expect(template).toContain("color: #333;");
-  });
-
-  it("should retrieve the scope from a search result", function() {
-    var documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
-
-    inject(function ($compile, $rootScope) {
-      $scope = $rootScope.$new();
-
-      $scope.document = {
-        content_type: "Journal",
-        issns: ["0028-4793"]
-      };
-
-      documentSummary = $compile(documentSummary)($scope);
+      expect(search.shouldEnhance(scope)).toEqual(false);
     });
 
-    var scope = search.getScope(documentSummary);
+    it("should enhance a journal search result with an issn", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0028-4793"]
+        }
+      };
 
-    expect(scope).toBeDefined();
-    expect(scope.document).toBeDefined();
-    expect(scope.document.content_type).toBeDefined();
-    expect(scope.document.issns).toBeDefined();
+      expect(search.shouldEnhance(scope)).toEqual(true);
+    });
 
-    expect(scope.document.content_type).toEqual("Journal");
-    expect(scope.document.issns).toEqual(["0028-4793"]);
+    it("should enhance an eJournal search result with an issn", function() {
+      var scope = {
+        document: {
+          content_type: "eJournal",
+          issns: ["0028-479X"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(true);
+    });
+
+    it("should enhance an article search result with a doi", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(true);
+    });
+
+    it("should not enhance a journal search result without an issn or eissn", function() {
+      var scope = {
+        document: {
+          content_type: "Journal"
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(false);
+    });
+
+    it("should not enhance an article search result without a doi", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article"
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(false);
+    });
+
+    it("should not enhance a journal search result without a content type", function() {
+      var scope = {
+        document: {
+          issns: ["0028-4793"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(false);
+    });
+
+    it("should not enhance an article search result without a content type", function() {
+      var scope = {
+        document: {
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(false);
+    });
+  });
+
+  describe("search model getEndpoint method", function() {
+    it("should build a journal endpoint for a journal search result", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0028-4793"]
+        }
+      };
+
+      expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
+    });
+
+    it("should select the issn over the eissn when a journal search result includes both", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0028-4793"],
+          eissns: ["0082-3974"]
+        }
+      };
+
+      expect(search.getEndpoint(scope)).toContain("search?issns=00284793");
+    });
+
+    it("should select the eissn when the journal search result has no issn", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          eissns: ["0082-3974"]
+        }
+      };
+
+      expect(search.getEndpoint(scope)).toContain("search?issns=00823974");
+    });
+
+    it("should build an article endpoint for an article search result", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575");
+    });
+
+    it("should build an article endpoint for an article search result and include its journal", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      expect(search.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575?include=journal");
+    });
+  });
+
+  describe("search model getBrowZineWebLink method", function() {
+    it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
+      var data = search.getData(journalResponse);
+      expect(data).toBeDefined();
+      expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
+    });
+
+    it("should include a browzineWebLink in the BrowZine API response for an article", function() {
+      var data = search.getData(articleResponse);
+      expect(data).toBeDefined();
+      expect(search.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+    });
+  });
+
+  describe("search model getCoverImageUrl method", function() {
+    it("should include a coverImageUrl in the BrowZine API response for a journal", function() {
+      var data = search.getData(journalResponse);
+      expect(data).toBeDefined();
+      expect(search.getCoverImageUrl(data, journalResponse)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+    });
+
+    it("should include a coverImageUrl in the BrowZine API response for an article", function() {
+      var data = search.getData(articleResponse);
+      expect(data).toBeDefined();
+      expect(search.getCoverImageUrl(data, articleResponse)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+    });
+
+    it("should not build a coverImageUrl when the BrowZine API response is missing the journal data type", function() {
+      var data = search.getData(journalResponse);
+      delete data.type;
+      expect(data).toBeDefined();
+      expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
+    });
+
+    it("should not build a coverImageUrl when the BrowZine API response is missing the article data type", function() {
+      var data = search.getData(articleResponse);
+      delete data.type;
+      expect(data).toBeDefined();
+      expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
+    });
+  });
+
+  describe("search model buildTemplate method", function() {
+    it("should build an enhancement template for journal search results", function() {
+      var data = search.getData(journalResponse);
+      var browzineWebLink = search.getBrowZineWebLink(data);
+      var template = search.buildTemplate(data, browzineWebLink);
+
+      expect(data).toBeDefined();
+      expect(browzineWebLink).toBeDefined();
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine'>View the Journal: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toContain("View the Journal");
+      expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
+      expect(template).toContain("Browse Now");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("text-decoration: underline;");
+      expect(template).toContain("color: #333;");
+    });
+
+    it("should build an enhancement template for article search results", function() {
+      var data = search.getData(articleResponse);
+      var browzineWebLink = search.getBrowZineWebLink(data);
+      var template = search.buildTemplate(data, browzineWebLink);
+
+      expect(data).toBeDefined();
+      expect(browzineWebLink).toBeDefined();
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toContain("View Complete Issue");
+      expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+      expect(template).toContain("Browse Now");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("text-decoration: underline;");
+      expect(template).toContain("color: #333;");
+    });
   });
 });

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -253,4 +253,29 @@ describe("Search Model", function() {
     expect(template).toContain("text-decoration: underline;");
     expect(template).toContain("color: #333;");
   });
+
+  it("should retrieve the scope from a search result", function() {
+    var documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+    $.extend(documentSummary, {
+      "jQuery321088802690231186742": {
+        "$scope": {
+          "document": {
+            content_type: "Journal",
+            issns: ["0028-4793"]
+          }
+        }
+      }
+    });
+
+    var scope = search.getScope(documentSummary);
+
+    expect(scope).toBeDefined();
+    expect(scope.document).toBeDefined();
+    expect(scope.document.content_type).toBeDefined();
+    expect(scope.document.issns).toBeDefined();
+
+    expect(scope.document.content_type).toEqual("Journal");
+    expect(scope.document.issns).toEqual(["0028-4793"]);
+  });
 });

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -57,7 +57,7 @@ describe("Search Model", function() {
     expect(search.shouldEnhance(scope)).toEqual(false);
   });
 
-  it("should detect whether a journal search result can be enhanced", function() {
+  it("should enhance a journal search result with an issn", function() {
     var scope = {
       document: {
         content_type: "Journal",
@@ -68,7 +68,7 @@ describe("Search Model", function() {
     expect(search.shouldEnhance(scope)).toEqual(true);
   });
 
-  it("should detect whether a eJournal search result can be enhanced", function() {
+  it("should enhance an eJournal search result with an issn", function() {
     var scope = {
       document: {
         content_type: "eJournal",
@@ -79,7 +79,7 @@ describe("Search Model", function() {
     expect(search.shouldEnhance(scope)).toEqual(true);
   });
 
-  it("should detect whether an article search result can be enhanced", function() {
+  it("should enhance an article search result with a doi", function() {
     var scope = {
       document: {
         content_type: "Journal Article",

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -51,6 +51,12 @@ describe("Search Model", function() {
     expect(search).toBeDefined();
   });
 
+  it("should not enhance a search result without a document", function() {
+    var scope = {};
+
+    expect(search.shouldEnhance(scope)).toEqual(false);
+  });
+
   it("should detect whether a journal search result can be enhanced", function() {
     var scope = {
       document: {

--- a/tests/unit/models/search.js
+++ b/tests/unit/models/search.js
@@ -1,4 +1,4 @@
-describe("Search Model", function() {
+describe("Search Model >", function() {
   var search = {}, journalResponse = {}, articleResponse = {};
 
   beforeEach(function() {
@@ -51,7 +51,7 @@ describe("Search Model", function() {
     expect(search).toBeDefined();
   });
 
-  describe("search model getScope method", function() {
+  describe("search model getScope method >", function() {
     it("should retrieve the scope from a search result", function() {
       var documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
@@ -78,7 +78,7 @@ describe("Search Model", function() {
     });
   });
 
-  describe("search model shouldEnhance method", function() {
+  describe("search model shouldEnhance method >", function() {
     it("should not enhance a search result without a document", function() {
       var scope = {};
 
@@ -89,6 +89,17 @@ describe("Search Model", function() {
       var scope = {
         document: {
           content_type: "Journal",
+          issns: ["0028-4793"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(true);
+    });
+
+    it("should enhance a journal search result with a lowercase content type", function() {
+      var scope = {
+        document: {
+          content_type: "journal",
           issns: ["0028-4793"]
         }
       };
@@ -111,6 +122,17 @@ describe("Search Model", function() {
       var scope = {
         document: {
           content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      expect(search.shouldEnhance(scope)).toEqual(true);
+    });
+
+    it("should enhance an article search result with a lowercase content type", function() {
+      var scope = {
+        document: {
+          content_type: "journal article",
           dois: ["10.1136/bmj.h2575"]
         }
       };
@@ -159,7 +181,7 @@ describe("Search Model", function() {
     });
   });
 
-  describe("search model getEndpoint method", function() {
+  describe("search model getEndpoint method >", function() {
     it("should build a journal endpoint for a journal search result", function() {
       var scope = {
         document: {
@@ -217,7 +239,7 @@ describe("Search Model", function() {
     });
   });
 
-  describe("search model getBrowZineWebLink method", function() {
+  describe("search model getBrowZineWebLink method >", function() {
     it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
       var data = search.getData(journalResponse);
       expect(data).toBeDefined();
@@ -231,39 +253,54 @@ describe("Search Model", function() {
     });
   });
 
-  describe("search model getCoverImageUrl method", function() {
+  describe("search model getCoverImageUrl method >", function() {
     it("should include a coverImageUrl in the BrowZine API response for a journal", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0082-3974"]
+        }
+      };
+
       var data = search.getData(journalResponse);
+      var journal = search.getIncludedJournal(journalResponse);
+
       expect(data).toBeDefined();
-      expect(search.getCoverImageUrl(data, journalResponse)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      expect(journal).toBeNull();
+
+      expect(search.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
 
     it("should include a coverImageUrl in the BrowZine API response for an article", function() {
-      var data = search.getData(articleResponse);
-      expect(data).toBeDefined();
-      expect(search.getCoverImageUrl(data, articleResponse)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
-    });
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
 
-    it("should not build a coverImageUrl when the BrowZine API response is missing the journal data type", function() {
-      var data = search.getData(journalResponse);
-      delete data.type;
-      expect(data).toBeDefined();
-      expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
-    });
-
-    it("should not build a coverImageUrl when the BrowZine API response is missing the article data type", function() {
       var data = search.getData(articleResponse);
-      delete data.type;
+      var journal = search.getIncludedJournal(articleResponse);
+
       expect(data).toBeDefined();
-      expect(search.getCoverImageUrl(data, journalResponse)).toBeNull();
+      expect(journal).toBeDefined();
+
+      expect(search.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
     });
   });
 
-  describe("search model buildTemplate method", function() {
+  describe("search model buildTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0082-3974"]
+        }
+      };
+
       var data = search.getData(journalResponse);
       var browzineWebLink = search.getBrowZineWebLink(data);
-      var template = search.buildTemplate(data, browzineWebLink);
+      var template = search.buildTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();
@@ -279,9 +316,16 @@ describe("Search Model", function() {
     });
 
     it("should build an enhancement template for article search results", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
       var data = search.getData(articleResponse);
       var browzineWebLink = search.getBrowZineWebLink(data);
-      var template = search.buildTemplate(data, browzineWebLink);
+      var template = search.buildTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();


### PR DESCRIPTION
Refactors to a MutationObserver and jQuery data sniffing to reduce reliance on Summon loading 3rd party scripts effectively. See, https://thirdiron.atlassian.net/browse/BZ-4161

Demo URL:
http://msulibrariestest.summon.serialssolutions.com/#!/search?ho=t&l=en&q=new%20england%20journal%20of%20medicine

Proposed Usage? We ask library developers to use this code snippet in their Summon 2.0 External Script:
```
var browzine = {
  api: "https://api.thirdiron.com/public/v1/libraries/XXX",
  apiKey: "ENTER API KEY"
};

browzine.script = document.createElement("script");
browzine.script.src = "https://s3.amazonaws.com/browzine-adapters/summon/browzine-summon-adapter.js";
document.head.appendChild(browzine.script);
```

Then we can push out enhancement of all sorts without the library ever having to touch the code again. :) Also, less code for the library to handle.
