### PR TITLE
feature/browzine-360-core-adapter-no-api-results-checks-02072018

### DIFF
--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -95,8 +95,10 @@ browzine.serSol360Core = (function() {
   function getBrowZineWebLink(data) {
     var browzineWebLink = null;
 
-    if(data.browzineWebLink) {
-      browzineWebLink = data.browzineWebLink;
+    if(data) {
+      if(data.browzineWebLink) {
+        browzineWebLink = data.browzineWebLink;
+      }
     }
 
     return browzineWebLink;
@@ -105,11 +107,25 @@ browzine.serSol360Core = (function() {
   function getCoverImageUrl(data) {
     var coverImageUrl = null;
 
-    if(data.coverImageUrl) {
-      coverImageUrl = data.coverImageUrl;
+    if(data) {
+      if(data.coverImageUrl) {
+        coverImageUrl = data.coverImageUrl;
+      }
     }
 
     return coverImageUrl;
+  };
+
+  function getBrowZineEnabled(data) {
+    var browzineEnabled = null;
+
+    if(data) {
+      if(data.browzineEnabled) {
+        browzineEnabled = data.browzineEnabled;
+      }
+    }
+
+    return browzineEnabled;
   };
 
   function buildTemplate(browzineWebLink) {
@@ -128,10 +144,6 @@ browzine.serSol360Core = (function() {
     template = template.replace(/{bookIcon}/g, bookIcon);
 
     return template;
-  };
-
-  function getBrowZineEnabled(data) {
-    return data.browzineEnabled;
   };
 
   function searchTitles(titles, callback) {

--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -95,10 +95,8 @@ browzine.serSol360Core = (function() {
   function getBrowZineWebLink(data) {
     var browzineWebLink = null;
 
-    if(data) {
-      if(data.browzineWebLink) {
-        browzineWebLink = data.browzineWebLink;
-      }
+    if(data && data.browzineWebLink) {
+      browzineWebLink = data.browzineWebLink;
     }
 
     return browzineWebLink;
@@ -107,10 +105,8 @@ browzine.serSol360Core = (function() {
   function getCoverImageUrl(data) {
     var coverImageUrl = null;
 
-    if(data) {
-      if(data.coverImageUrl) {
-        coverImageUrl = data.coverImageUrl;
-      }
+    if(data && data.coverImageUrl) {
+      coverImageUrl = data.coverImageUrl;
     }
 
     return coverImageUrl;
@@ -119,10 +115,8 @@ browzine.serSol360Core = (function() {
   function getBrowZineEnabled(data) {
     var browzineEnabled = null;
 
-    if(data) {
-      if(data.browzineEnabled) {
-        browzineEnabled = data.browzineEnabled;
-      }
+    if(data && data.browzineEnabled) {
+      browzineEnabled = data.browzineEnabled;
     }
 
     return browzineEnabled;

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -149,6 +149,14 @@ describe("SerSol 360 Core Model >", function() {
       expect(data).toBeDefined();
       expect(serSol360Core.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
     });
+
+    it("should return null when the BrowZine API response for a journal is empty", function() {
+      var data = serSol360Core.getData({
+        "data": []
+      });
+      expect(data).toBeUndefined();
+      expect(serSol360Core.getBrowZineWebLink(data)).toEqual(null);
+    });
   });
 
   describe("serSol360Core model getCoverImageUrl method >", function() {
@@ -157,6 +165,14 @@ describe("SerSol 360 Core Model >", function() {
       expect(data).toBeDefined();
       expect(serSol360Core.getCoverImageUrl(data)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
+
+    it("should return null when the BrowZine API response for a journal is empty", function() {
+      var data = serSol360Core.getData({
+        "data": []
+      });
+      expect(data).toBeUndefined();
+      expect(serSol360Core.getCoverImageUrl(data)).toEqual(null);
+    });
   });
 
   describe("serSol360Core model getBrowZineEnabled method >", function() {
@@ -164,6 +180,14 @@ describe("SerSol 360 Core Model >", function() {
       var data = serSol360Core.getData(journalResponse);
       expect(data).toBeDefined();
       expect(serSol360Core.getBrowZineEnabled(data)).toEqual(true);
+    });
+
+    it("should return null when the BrowZine API response for a journal is empty", function() {
+      var data = serSol360Core.getData({
+        "data": []
+      });
+      expect(data).toBeUndefined();
+      expect(serSol360Core.getBrowZineEnabled(data)).toEqual(null);
     });
   });
 


### PR DESCRIPTION
## Summary - [BZ-4334](https://thirdiron.atlassian.net/browse/BZ-4334)
Handles a valid ISSN search with no Public API search results. See, [Slack Conversation with John](https://thirdiron.slack.com/archives/C6ND59F7C/p1518022587000057)

## Deploy Precautions
- None 